### PR TITLE
update to support tf provider v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2023-10-19
+### Changed
+- Upgrade dependencies: Add TF Google provider 5 support
+
 ## [1.0.1] - 2023-05-23
 ### Added
 - Added missing changelog

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you require a GCS module that supports a terraform version < 1.3.0 than i sug
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, < 2.0.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.0.0, < 6.0.0 |
 <!-- END_TF_DOCS -->
 
 ### Service Account

--- a/examples/basic_buckets/versions.tf
+++ b/examples/basic_buckets/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }


### PR DESCRIPTION
No breaking changes introduced with the bucket resource, so we should be safe to allow v5 provider support. 
There will be a no-op for existing labels due to the change in how V5 handles the labels now but will be a onetime change